### PR TITLE
Fix for AWAY raws causing empty output

### DIFF
--- a/script/ptm/rawdisp.ptm
+++ b/script/ptm/rawdisp.ptm
@@ -1651,7 +1651,7 @@ alias -l _in.whois {
 
 ; Also catches all (incl 307) while in the middle of a whois, unless prev halted
 raw *:*:{
-  if ($numeric !isnum) return
+  if ($numeric !isnum || $numeric == 0) return
   if ($halted) return
 
   ; In a whois?


### PR DESCRIPTION
Other users' AWAY events cause an empty line to be output to the channel window. The * handler wasn't properly accounting for events with numeric 0.